### PR TITLE
Fix issues with reloadPatchers

### DIFF
--- a/src/Services/patcherService.js
+++ b/src/Services/patcherService.js
@@ -6,11 +6,16 @@ module.exports = function({ngapp, moduleUrl, fh}) {
 
         let service = this,
             patchers = [],
+            tabs = [];
+
+        this.resetTabs = function () {
             tabs = [{
                 label: 'Build Patches',
                 templateUrl: `${moduleUrl}/partials/buildPatches.html`,
                 controller: 'buildPatchesController'
             }];
+        }
+        this.resetTabs();
 
         // private functions
         let getAvailableFiles = function(patcher) {
@@ -187,6 +192,7 @@ module.exports = function({ngapp, moduleUrl, fh}) {
                 $cacheFactory.get('templates').remove(tab.templateUrl);
             });
             tabs = [];
+            service.resetTabs();
             service.reloadPatchers();
             service.loadSettings();
         });


### PR DESCRIPTION
Fixes #13

Adds a new function that resets the tabs array to contain the patcher tab when reloadPatchers happens, rather than starting from an empty list.